### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,6 +1,7 @@
 {
     "perl"        : "6.c",
     "name"        : "Net::FTPlib",
+    "license"     : "MIT",
     "version"     : "0.2.0",
     "description" : "A Perl 6 binding for ftplib (http://nbpfaus.net/~pfau/ftplib)",
     "depends"     : [],


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license